### PR TITLE
Set context to null when caneclling connection

### DIFF
--- a/Acr.Ble.Android/Device.cs
+++ b/Acr.Ble.Android/Device.cs
@@ -138,6 +138,7 @@ namespace Acr.Ble
 
             this.connSubject.OnNext(ConnectionStatus.Disconnecting);
             this.context.Close();
+            this.context = null;
             this.connSubject.OnNext(ConnectionStatus.Disconnected);
         }
 


### PR DESCRIPTION
Once you have disconnected a device, you will need to re-scan in order to connect the device again. Setting the context to null forces the context/connection to be reinitialized which allows you to reconnect to the device.