### PR TITLE
remove null check preventing BlutetoothLE adverts raising scan results

### DIFF
--- a/Plugin.BluetoothLE.Uwp/Adapter.cs
+++ b/Plugin.BluetoothLE.Uwp/Adapter.cs
@@ -166,12 +166,12 @@ namespace Plugin.BluetoothLE
                                     if (btDevice != null)
                                         device = this.context.AddDevice(args.BluetoothAddress, btDevice);
                                 }
-                                if (device != null)
-                                {
+                                //if (device != null)
+                                //{
                                     var adData = new AdvertisementData(args);
                                     var scanResult = new ScanResult(device, args.RawSignalStrengthInDBm, adData);
                                     ob.OnNext(scanResult);
-                                }
+                                //}
                             });
                     }
                 })


### PR DESCRIPTION
the function call BluetoothLEDevice.FromBluetoothAddressAsync will return null if the device is not paired, see: https://social.msdn.microsoft.com/Forums/windowsapps/en-US/d98df6bf-616a-4f1f-b1ab-1e97e66de50c/is-bluetoothledevicefrombluetoothaddressasync-broken-or-am-i-using-it-wrong?forum=wpdevelop
this means that the null check for the returned device always fails causing advertisements not to raise scan results.