### PR TITLE
(UWP) Remove dependency on CoreWindow for SetNotificationValue

### DIFF
--- a/Plugin.BluetoothLE.Uwp/GattCharacteristic.cs
+++ b/Plugin.BluetoothLE.Uwp/GattCharacteristic.cs
@@ -77,10 +77,10 @@ namespace Plugin.BluetoothLE
             {
                 var tcs = new TaskCompletionSource<GattCommunicationStatus>();
                 await Task.Run(async () =>
-                        {
-                            var desc = GetConfigValue(value);
-                            var result = await this.Native.WriteClientCharacteristicConfigurationDescriptorAsync(desc);
-                            tcs.TrySetResult(result);
+                {
+                    var desc = GetConfigValue(value);
+                    var result = await this.Native.WriteClientCharacteristicConfigurationDescriptorAsync(desc);
+                    tcs.TrySetResult(result);
                 });
 
                 var status = await tcs.Task;

--- a/Plugin.BluetoothLE.Uwp/GattCharacteristic.cs
+++ b/Plugin.BluetoothLE.Uwp/GattCharacteristic.cs
@@ -76,18 +76,12 @@ namespace Plugin.BluetoothLE
             return Observable.FromAsync(async ct =>
             {
                 var tcs = new TaskCompletionSource<GattCommunicationStatus>();
-                await CoreWindow
-                    .GetForCurrentThread()
-                    .Dispatcher
-                    .RunAsync(
-                        CoreDispatcherPriority.Normal,
-                        async () =>
+                await Task.Run(async () =>
                         {
                             var desc = GetConfigValue(value);
                             var result = await this.Native.WriteClientCharacteristicConfigurationDescriptorAsync(desc);
                             tcs.TrySetResult(result);
-                        }
-                    );
+                });
 
                 var status = await tcs.Task;
                 if (status == GattCommunicationStatus.Success)


### PR DESCRIPTION
Calling SetNotificationValue (or RegisterAndNotify) before a UI window is created crashes with a NullReferenceException due to the lack of a CoreWindow.