### PR TITLE
Null ref error, app crahes, android 5.0.2 (lollipop)

### DIFF
--- a/Plugin.BluetoothLE.Android/Internals/AdapterContext.cs
+++ b/Plugin.BluetoothLE.Android/Internals/AdapterContext.cs
@@ -47,7 +47,7 @@ namespace Plugin.BluetoothLE.Internals
         {
             if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
             {
-                this.manager.Adapter.BluetoothLeScanner.StopScan(this.newCallback);
+                this.manager.Adapter.BluetoothLeScanner?.StopScan(this.newCallback);
             }
             else
             {


### PR DESCRIPTION
Hi @aritchie!
There is a bug on my android (5.0.2) lollipop.
Steps to reproduce:
1. open app on android 5 (lollipop), turn on bluetooth
2. turn off bluetooth
ERROR: app crashes (see stack trace below)

Please review this change, plz!
-------------
11-27 12:41:27.565	Xiaomi Redmi Note 2	Info	31136	MonoDroid	System.NullReferenceException: Object reference not set to an instance of an object
at Plugin.BluetoothLE.Internals.BleContext.StopScan () [0x00022] in <caa006f1bd534db488dde50dc1db5d75>:0 
at Plugin.BluetoothLE.Adapter+<>c_DisplayClass19_1.<Scan>b_1 () [0x00001] in <caa006f1bd534db488dde50dc1db5d75>:0 
at System.Reactive.Disposables.AnonymousDisposable.Dispose () [0x00010] in <99f8205c51c44bb480747b577b8001ff>:0 
at System.Reactive.Disposables.SingleAssignmentDisposable.Dispose () [0x00014] in <99f8205c51c44bb480747b577b8001ff>:0 
at System.Reactive.AutoDetachObserver`1[T].Dispose (System.Boolean disposing) [0x0000a] in <99f8205c51c44bb480747b577b8001ff>:0 
at System.Reactive.ObserverBase`1[T].Dispose () [0x00000] in <99f8205c51c44bb480747b577b8001ff>:0 
at ColaSetup.Services.BLE.ComaBLE.handleAdapterStatus (Plugin.BluetoothLE.AdapterStatus status) [0x000c6] in <d7f2728bc9f24455a9b20469708be47e>:0 
at ColaSetup.Services.BLE.ComaBLE+<>c.<get_Singleton>b__31_0 (Plugin.BluetoothLE.AdapterStatus status) [0x00000] in <d7f2728bc9f24455a9b20469708be47e>:0 
at System.Reactive.AnonymousSafeObserver`1[T].OnNext (T value) [0x0000a] in <99f8205c51c44bb480747b577b8001ff>:0 
at System.Reactive.Linq.ObservableImpl.RefCount`1+_[TSource].OnNext (TSource value) [0x00000] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Subjects.FastImmediateObserver`1[T].EnsureActive (System.Int32 count) [0x0016b] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Subjects.FastImmediateObserver`1[T].EnsureActive () [0x00000] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Subjects.ReplaySubject`1+ReplayBase[T].OnNext (T value) [0x0006e] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Subjects.ReplaySubject`1[T].OnNext (T value) [0x00000] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Linq.ObservableImpl.AsObservable`1+_[TSource].OnNext (TSource value) [0x00000] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Linq.ObservableImpl.Select`2+_[TSource,TResult].OnNext (TSource value) [0x00033] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.Linq.ObservableImpl.Concat`1+_[TSource].OnNext (TSource value) [0x00000] in <e9c1ccec51844dbd92b833a0b4bc960e>:0 
at System.Reactive.AutoDetachObserver`1[T].OnNextCore (T value) [0x00002] in <99f8205c51c44bb480747b577b8001ff>:0 
at System.Reactive.ObserverBase`1[T].OnNext (T value) [0x0000d] in <99f8205c51c44bb480747b577b8001ff>:0 
at Plugin.BluetoothLE.Internals.ObservableBroadcastReceiver.OnReceive (Android.Content.Context context, Android.Content.Intent intent) [0x00021] in <caa006f1bd534db488dde50dc1db5d75>:0 
at Android.Content.BroadcastReceiver.n_OnReceive_Landroid_content_Context_Landroid_content_Intent_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_context, System.IntPtr native_intent) [0x00017] in <9ef29c909d7e4606a46b131129da3975>:0 
at (wrapper dynamic-method) System.Object:4e9fbffc-dae4-493b-b955-29f7a6b1fdcc (intptr,intptr,intptr,intptr)