### PR TITLE
#105 Call Adapter.scanStatusChanged only after actually changing scan status

### DIFF
--- a/Plugin.BluetoothLE/Platforms/Android/Adapter.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Adapter.cs
@@ -128,8 +128,8 @@ namespace Plugin.BluetoothLE
             if (this.IsScanning)
                 throw new ArgumentException("There is already an active scan");
 
-            this.scanStatusChanged.OnNext(true);
             this.isScanning = true;
+            this.scanStatusChanged.OnNext(true);
 
             return this.context
                 .Scan(config ?? new ScanConfig())


### PR DESCRIPTION
Adapter.IsScanning should be the same as the parameter given to the observer at the time the observer is notified.  That way, if the observer wants to use Adapter.IsScanning in some way, it can expect that value to be correct.

An example of this use case would be triggering PropertyChanged event for a xaml-bound property that points to Adapter.IsScanning,  