### PR TITLE
this enables support for scan batching on android

### DIFF
--- a/Plugin.BluetoothLE/Platforms/Android/Internals/AdapterContext.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Internals/AdapterContext.cs
@@ -75,11 +75,14 @@ namespace Plugin.BluetoothLE.Internals
                 }
             }
 
-            this.manager.Adapter.BluetoothLeScanner.StartScan(
-                scanFilters,
-                new ScanSettings
-                    .Builder()
-                    .SetScanMode(scanMode)
+            var supportsScanBatching = this.manager.Adapter.IsOffloadedScanBatchingSupported;
+
+        this.manager.Adapter.BluetoothLeScanner.StartScan(
+            scanFilters,
+            new ScanSettings
+                .Builder()
+                .SetScanMode(scanMode)
+                .SetReportDelay(supportsScanBatching && config.AllowScanBatchingIfSupported ? 100:0)
                     .Build(),
                 this.callbacks
             );

--- a/Plugin.BluetoothLE/Platforms/Android/Internals/LollipopScanCallback.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Internals/LollipopScanCallback.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Android.Bluetooth;
 using Android.Bluetooth.LE;
 using SR = Android.Bluetooth.LE.ScanResult;
@@ -17,5 +18,11 @@ namespace Plugin.BluetoothLE.Internals
 
         public override void OnScanResult(ScanCallbackType callbackType, SR result)
             => this.callback(result.Device, result.Rssi, result.ScanRecord);
+
+        public override void OnBatchScanResults(IList<SR> results)
+        {
+            if (results == null) return;
+            foreach (SR result in results) this.callback(result.Device, result.Rssi, result.ScanRecord);
+        }
     }
 }

--- a/Plugin.BluetoothLE/ScanConfig.cs
+++ b/Plugin.BluetoothLE/ScanConfig.cs
@@ -12,6 +12,14 @@ namespace Plugin.BluetoothLE
 
 
         /// <summary>
+        /// Allows the use of Scan Batching, if supported by the underlying provider
+        /// Currently, this only affects Android devices
+        /// It defaults to false to be transparent/non-breaking with existing code
+        /// </summary>
+        public bool AllowScanBatchingIfSupported { get; set; } = false;
+
+
+        /// <summary>
         /// Filters scan to devices that advertise specified service UUIDs
         /// iOS - you must set this to initiate a background scan
         /// </summary>


### PR DESCRIPTION
We added support for Android's scan batching feature, for devices that support it. This can drastically improve the number of advertisements observed. By default the use of scan batching in this modification is disabled to be transparent for existing applications using the plugin. It is allowed via a flag added to scanconfig. Only android uses that flag. All other platforms would ignore it. We would greatly appreciate this feature being added to the plugin code base! Thank you!