### PR TITLE
Clean buffer after blob write

### DIFF
--- a/Plugin.BluetoothLE.Tests/CharacteristicTests.cs
+++ b/Plugin.BluetoothLE.Tests/CharacteristicTests.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Acr.UserDialogs;
+using Plugin.BluetoothLE.Tests.Mocks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -208,6 +209,47 @@ namespace Plugin.BluetoothLE.Tests
             sub.Dispose();
 
             await Task.Delay(1000);
+        }
+
+        [Fact]
+        public async Task BlockWrite_TestBufferClearing()
+        {
+            const int mtuSize = 512;
+            var transaction = new MockGattReliableWriteTransaction();
+            var service = new MockGattService()
+            {
+                Device = new MockDevice()
+                {
+                    MtuSize = mtuSize,
+                    Uuid = Guid.NewGuid(),
+                    Transaction = transaction
+                }
+            };
+            var characteristic = new MockGattCharacteristic(service, service.Uuid, CharacteristicProperties.Write);
+
+            // Ensure write will span multiple packets
+            var blob = new byte[mtuSize + (mtuSize / 2)];
+            // Fill first packet's worth with 1s
+            for (var i = 0; i < mtuSize; i++)
+            {
+                blob[i] = 1;
+            }
+
+            // Fill second packet's worth with 2s
+            for (var i = mtuSize; i < blob.Length; i++)
+            {
+                blob[i] = 2;
+            }
+
+            await characteristic.BlobWrite(blob, true).FirstAsync(segment => segment.Position == segment.TotalLength);
+
+            // First packet should be all 1s
+            Assert.True(transaction.WrittenValues.First().All(val => val == 1));
+            Assert.True(transaction.WrittenValues.First().Where(val => val == 1).Count() == blob.Where(val => val == 1).Count());
+            // Second packet should be half 2s and half 0s
+            Assert.True(transaction.WrittenValues.Last().Take(mtuSize / 2).All(val => val == 2));
+            Assert.True(transaction.WrittenValues.Last().Where(val => val == 2).Count() == blob.Where(val => val == 2).Count());
+            Assert.True(transaction.WrittenValues.Last().Skip(mtuSize / 2).All(val => val == 0));
         }
     }
 }

--- a/Plugin.BluetoothLE.Tests/Mocks/MockDevice.cs
+++ b/Plugin.BluetoothLE.Tests/Mocks/MockDevice.cs
@@ -1,0 +1,82 @@
+﻿using System;
+namespace Plugin.BluetoothLE.Tests.Mocks
+{
+    public class MockDevice : IDevice
+    {
+        public object NativeDevice => throw new NotImplementedException();
+
+        public DeviceFeatures Features => throw new NotImplementedException();
+
+        public string Name => throw new NotImplementedException();
+
+        public Guid Uuid { get; set; }
+
+        public int MtuSize { get; set; }
+
+        public PairingStatus PairingStatus => throw new NotImplementedException();
+
+        public ConnectionStatus Status => throw new NotImplementedException();
+
+        public MockGattReliableWriteTransaction Transaction { get; set; }
+
+        public IGattReliableWriteTransaction BeginReliableWriteTransaction()
+        {
+            return  this.Transaction ?? new MockGattReliableWriteTransaction(); 
+        }
+
+        public void CancelConnection()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Connect(ConnectionConfig config = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<IGattService> DiscoverServices()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<IGattService> GetKnownService(Guid serviceUuid)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<bool> PairingRequest(string pin = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<int> ReadRssi()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<int> RequestMtu(int size)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<BleException> WhenConnectionFailed()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<int> WhenMtuChanged()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<string> WhenNameUpdated()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<ConnectionStatus> WhenStatusChanged()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Plugin.BluetoothLE.Tests/Mocks/MockGattCharacteristic.cs
+++ b/Plugin.BluetoothLE.Tests/Mocks/MockGattCharacteristic.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reactive.Linq;
+
+namespace Plugin.BluetoothLE.Tests.Mocks
+{
+    public class MockGattCharacteristic : AbstractGattCharacteristic
+    {
+        public MockGattCharacteristic(IGattService service, Guid guid, CharacteristicProperties properties)
+            : base(service, guid, properties) 
+        { 
+        }
+
+        private byte[] _value;
+        public override byte[] Value => this._value;
+
+        public override IObservable<CharacteristicGattResult> DisableNotifications()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IObservable<IGattDescriptor> DiscoverDescriptors()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IObservable<CharacteristicGattResult> EnableNotifications(bool enableIndicationsIfAvailable)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IObservable<CharacteristicGattResult> Read()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IObservable<CharacteristicGattResult> WhenNotificationReceived()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IObservable<CharacteristicGattResult> Write(byte[] value)
+        {
+            this._value = value;
+            return Observable.Create<CharacteristicGattResult>(obs =>
+            {
+                obs.OnNext(new CharacteristicGattResult(this, value));
+                obs.OnCompleted();
+                return () => { };
+            });
+        }
+
+        public override IObservable<CharacteristicGattResult> WriteWithoutResponse(byte[] value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Plugin.BluetoothLE.Tests/Mocks/MockGattReliableWriteTransaction.cs
+++ b/Plugin.BluetoothLE.Tests/Mocks/MockGattReliableWriteTransaction.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+
+namespace Plugin.BluetoothLE.Tests.Mocks
+{
+    public class MockGattReliableWriteTransaction : IGattReliableWriteTransaction
+    {
+        public TransactionStatus Status => TransactionStatus.Active;
+
+        public List<byte[]> WrittenValues { get; set; } = new List<byte[]>();
+
+        public void Abort()
+        {
+        }
+
+        public IObservable<Unit> Commit()
+        {
+            return Observable.Create<Unit>(obs =>
+            {
+                obs.OnCompleted();
+                return () => { };
+            });
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public IObservable<CharacteristicGattResult> Write(IGattCharacteristic characteristic, byte[] value)
+        {
+            this.WrittenValues.Add(value.ToArray());
+            return characteristic.Write(value);
+        }
+    }
+}

--- a/Plugin.BluetoothLE.Tests/Mocks/MockGattService.cs
+++ b/Plugin.BluetoothLE.Tests/Mocks/MockGattService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+namespace Plugin.BluetoothLE.Tests.Mocks
+{
+    public class MockGattService : IGattService
+    {
+
+        public IDevice Device { get; set; }
+
+        public Guid Uuid => this.Device?.Uuid ?? Guid.NewGuid();
+
+        public string Description => throw new NotImplementedException();
+
+        public IObservable<IGattCharacteristic> DiscoverCharacteristics()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IObservable<IGattCharacteristic> GetKnownCharacteristics(params Guid[] characteristicIds)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Plugin.BluetoothLE/AbstractGattCharacteristic.cs
+++ b/Plugin.BluetoothLE/AbstractGattCharacteristic.cs
@@ -70,6 +70,15 @@ namespace Plugin.BluetoothLE
                         ob.OnNext(seg);
 
                         read = stream.Read(buffer, 0, buffer.Length);
+
+                        if (read > 0 && read < buffer.Length)
+                        {
+                            for (var index = read; index < buffer.Length; index++)
+                            {
+                                buffer[index] = 0;
+                            }
+                        }
+
                         pos += read;
                     }
                     await trans.Commit();


### PR DESCRIPTION
When a message is written that spans multiple transmission units, the buffer used to write data one MTU-sized chunk at a time is not cleared after writing.

For messages shorter than the MTU size, this isn't an issue.  When a message is split into multiple chunks and does not divide evenly by MTU size, however, the last packet sent will have garbage data leftover from the previous packet filling whatever space wasn't written over.

This adds a check to the AbstractGattCharacteristic's BlobWrite method that will overwrite any unused bytes with 0 before sending the final packet.