### PR TITLE
faster device Clean() at the start of a Scan() for Android

### DIFF
--- a/Plugin.BluetoothLE/Platforms/Android/Adapter.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Adapter.cs
@@ -55,10 +55,12 @@ namespace Plugin.BluetoothLE
             .ToList();
 
 
-        public override IEnumerable<IDevice> GetConnectedDevices() => this.manager
+        public override IEnumerable<IDevice> GetConnectedDevices() => this.context.Devices.GetConnectedDevices();
+
+        /*public override IEnumerable<IDevice> GetConnectedDevices() => this.manager
             .GetConnectedDevices(ProfileType.Gatt)
             .Select(this.context.Devices.GetDevice)
-            .Where(x => x.Status == ConnectionStatus.Connected);
+            .Where(x => x.Status == ConnectionStatus.Connected);/**/
 
 
         public override AdapterStatus Status

--- a/Plugin.BluetoothLE/Platforms/Android/Internals/DeviceManager.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Internals/DeviceManager.cs
@@ -11,6 +11,7 @@ namespace Plugin.BluetoothLE.Internals
     {
         readonly ConcurrentDictionary<string, IDevice> devices = new ConcurrentDictionary<string, IDevice>();
         readonly BluetoothManager manager;
+        readonly List<ConnectionStatus> nonconnectedstates = new List<ConnectionStatus>() { ConnectionStatus.Connecting, ConnectionStatus.Disconnected, ConnectionStatus.Disconnecting };
 
 
         public DeviceManager(BluetoothManager manager)
@@ -24,16 +25,69 @@ namespace Plugin.BluetoothLE.Internals
             x => new Device(this.manager, btDevice)
         );
 
+        public List<IDevice> GetDevicesWithConnectionState(ConnectionStatus state)
+        {
+            int[] btstates = new int[1];
+            switch (state)
+            {
+                case ConnectionStatus.Disconnected: btstates[0] = (int)ProfileState.Disconnected; break;
+                case ConnectionStatus.Disconnecting: btstates[0] = (int)ProfileState.Disconnecting; break;
+                case ConnectionStatus.Connecting: btstates[0] = (int)ProfileState.Connecting; break;
+                case ConnectionStatus.Connected: btstates[0] = (int)ProfileState.Connected; break;
+            }
+            IList<BluetoothDevice> devs = manager.GetDevicesMatchingConnectionStates(ProfileType.Gatt, btstates);
+            List<IDevice> res = new List<IDevice>();
+            foreach (BluetoothDevice d in devs)
+            {
+                IDevice id = GetDevice(d); if (id != null) res.Add(id);
+            }
+            return res;
+        }
+        public List<IDevice> GetDevicesWithConnectionStates(List<ConnectionStatus> states)
+        {
+            int statecount = states.Count;
+            int[] btstates = new int[statecount];            
+            for (int i=0;i< statecount;++i)
+            {
+                switch(states[i])
+                {
+                    case ConnectionStatus.Disconnected: btstates[i] = (int)ProfileState.Disconnected;break;
+                    case ConnectionStatus.Disconnecting: btstates[i] = (int)ProfileState.Disconnecting; break;
+                    case ConnectionStatus.Connecting: btstates[i] = (int)ProfileState.Connecting; break;
+                    case ConnectionStatus.Connected: btstates[i] = (int)ProfileState.Connected; break;
+                }
+            }
+            IList<BluetoothDevice> devs= manager.GetDevicesMatchingConnectionStates(ProfileType.Gatt, btstates);
+            List<IDevice> res = new List<IDevice>();
+            foreach (BluetoothDevice d in devs)
+            {
+                IDevice id=GetDevice(d);if (id != null) res.Add(id);
+            }
+            return res;
+        }
+        private List<string> GetDeviceAddressesWithConnectionStates(List<ConnectionStatus> states)
+        {
+            int statecount = states.Count;
+            int[] btstates = new int[statecount];
+            for (int i = 0; i < statecount; ++i)
+            {
+                switch (states[i])
+                {
+                    case ConnectionStatus.Disconnected: btstates[i] = (int)ProfileState.Disconnected; break;
+                    case ConnectionStatus.Disconnecting: btstates[i] = (int)ProfileState.Disconnecting; break;
+                    case ConnectionStatus.Connecting: btstates[i] = (int)ProfileState.Connecting; break;
+                    case ConnectionStatus.Connected: btstates[i] = (int)ProfileState.Connected; break;
+                }
+            }
+            IList<BluetoothDevice> devs = manager.GetDevicesMatchingConnectionStates(ProfileType.Gatt, btstates);
+            List<string> res = new List<string>();
+            foreach (BluetoothDevice d in devs) res.Add(d.Address);
+            return res;
+        }
 
-        public IEnumerable<IDevice> GetConnectedDevices() => this.devices
-            .Where(x => x.Value.Status == ConnectionStatus.Connected)
-            .Select(x => x.Value)
-            .ToList();
-
-
-        public void Clear() => this.devices
-            .Where(x => x.Value.Status != ConnectionStatus.Connected)
-            .ToList()
-            .ForEach(x => this.devices.TryRemove(x.Key, out _));
+        public IEnumerable<IDevice> GetConnectedDevices() => GetDevicesWithConnectionState(ConnectionStatus.Connected);
+        
+        public void Clear() => GetDeviceAddressesWithConnectionStates(nonconnectedstates)
+            .ForEach(x => this.devices.TryRemove(x, out _));
     }
 }

--- a/Plugin.BluetoothLE/Platforms/Android/Internals/DeviceManager.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Internals/DeviceManager.cs
@@ -43,6 +43,22 @@ namespace Plugin.BluetoothLE.Internals
             }
             return res;
         }
+        private List<string> GetDeviceAddressesWithConnectionState(ConnectionStatus state)
+        {
+            int[] btstates = new int[1];
+            switch (state)
+            {
+                case ConnectionStatus.Disconnected: btstates[0] = (int)ProfileState.Disconnected; break;
+                case ConnectionStatus.Disconnecting: btstates[0] = (int)ProfileState.Disconnecting; break;
+                case ConnectionStatus.Connecting: btstates[0] = (int)ProfileState.Connecting; break;
+                case ConnectionStatus.Connected: btstates[0] = (int)ProfileState.Connected; break;
+            }
+            IList<BluetoothDevice> devs = manager.GetDevicesMatchingConnectionStates(ProfileType.Gatt, btstates);
+            List<string> res = new List<string>();
+            foreach (BluetoothDevice d in devs) res.Add(d.Address);
+            return res;
+        }
+
         public List<IDevice> GetDevicesWithConnectionStates(List<ConnectionStatus> states)
         {
             int statecount = states.Count;
@@ -86,8 +102,15 @@ namespace Plugin.BluetoothLE.Internals
         }
 
         public IEnumerable<IDevice> GetConnectedDevices() => GetDevicesWithConnectionState(ConnectionStatus.Connected);
-        
-        public void Clear() => GetDeviceAddressesWithConnectionStates(nonconnectedstates)
+        private IEnumerable<string> GetConnectedDeviceAddresses() => GetDeviceAddressesWithConnectionState(ConnectionStatus.Connected);
+
+        public IEnumerable<IDevice> GetNonconnectedDevices() => this.devices.Values.Except(GetConnectedDevices());
+        private IEnumerable<string> GetNonconnectedDeviceAddresses() => this.devices.Keys.Except(GetConnectedDeviceAddresses());
+
+
+        public void Clear() => GetNonconnectedDeviceAddresses()
+            .ToList()
             .ForEach(x => this.devices.TryRemove(x, out _));
+
     }
 }


### PR DESCRIPTION
When facing a situation where during the previous scan a large number of devices were discovered, the cleanup of that list in the current implementation took several seconds, because for each device the Status was checked, which involved a call to Android to get the connection status of the internal BluetoothDevice via .GetConnectionState(this.context.NativeDevice, ProfileType.Gatt). Instead, the code in this PR replaces this with a single call to get all connected devices, then generating a List<string> of all current IDevices in the device list except those that are connected, and then using that list and ForEach to attempt removal from the devices list. This collapses thousands of OS calls into a single one. In our test case with 4000 BLE devices the Clean() call duration went from about 10 seconds to just a few milliseconds. This is key for us, because it allows fairly fast scan cycling (start-wait-stop-restart) of scans. Thank you for considering this PR! Please let me know if I can provide any additional information.