### PR TITLE
UWP: readout mtu size

### DIFF
--- a/Plugin.BluetoothLE/Platforms/Uwp/Device.cs
+++ b/Plugin.BluetoothLE/Platforms/Uwp/Device.cs
@@ -97,5 +97,9 @@ namespace Plugin.BluetoothLE
             var state = result.Status == DevicePairingResultStatus.Paired;
             return state;
         });
+
+        public override IObservable<int> WhenMtuChanged() => this.context.WhenMtuChanged();
+
+        public override int MtuSize => this.context.MtuSize ?? base.MtuSize;
     }
 }


### PR DESCRIPTION
Like iOS UWP apps also negotiates the MTU aka PDU size automatically with the device upon connection.

Added implementation to readout this value (IDevice.MtuSize).



