### PR TITLE
Fix for connecthook with many characteristics

### DIFF
--- a/Plugin.BluetoothLE/Extensions_Device.cs
+++ b/Plugin.BluetoothLE/Extensions_Device.cs
@@ -93,7 +93,7 @@ namespace Plugin.BluetoothLE
                     .Select(_ => device.WhenKnownCharacteristicsDiscovered(serviceUuid, characteristicUuids))
                     .Switch()
                     .Select(x => x.RegisterAndNotify(false, false))
-                    .Switch()
+                    .Merge()
                     .Subscribe(
                         ob.OnNext,
                         ob.OnError


### PR DESCRIPTION
Fix for connecthook with many characteristics

### Description of Change ###
Switch took only the last characterstic in the list and cut out all other emissions, now it doesn't

### Issues Resolved ### 
- fixes #360 

### API Changes ###
 None

### Platforms Affected ### 
- All

### Behavioral Changes ###
None

### Testing Procedure ###
Use connecthook to hook to many characteristics of a BT device, let's say 5 characteristics
You'll now receive notifications from the connecthook subscription from all of them and not only from the fifth.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard