### PR TITLE
advertise localName on android

### DIFF
--- a/Plugin.BluetoothLE/Platforms/Android/Server/Advertiser.cs
+++ b/Plugin.BluetoothLE/Platforms/Android/Server/Advertiser.cs
@@ -36,14 +36,33 @@ namespace Plugin.BluetoothLE.Server
             foreach (var serviceUuid in adData.ServiceUuids)
                 data.AddServiceUuid(serviceUuid.ToParcelUuid());
 
-            this.manager
-                .Adapter
-                .BluetoothLeAdvertiser
-                .StartAdvertising(
-                    settings.Build(),
-                    data.Build(),
-                    this.adCallbacks
-                );
+            if (string.IsNullOrEmpty(adData.LocalName) || adData.AndroidUseDeviceName)
+            {
+                this.manager
+                    .Adapter
+                    .BluetoothLeAdvertiser
+                    .StartAdvertising(
+                        settings.Build(),
+                        data.Build(),
+                        this.adCallbacks
+                    );
+            }
+            else
+            {
+                this.manager
+                    .Adapter.SetName(adData.LocalName);
+                var scanResponse = new AdvertiseData.Builder()
+                    .SetIncludeDeviceName(true);
+                this.manager
+                    .Adapter
+                    .BluetoothLeAdvertiser
+                    .StartAdvertising(
+                        settings.Build(),
+                        data.Build(),
+                        scanResponse.Build(),
+                        this.adCallbacks
+                    );
+            }
 
             base.Start(adData);
         }


### PR DESCRIPTION
### Description of Change ###

Provide to advertise the localName on Android in the ScanResponse; this is the same behaviour as on iOS.

### Issues Resolved ### 

- fixes #375

### API Changes ###
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###

The LocalName is advertised when set and AndroidUseDeviceName is false.

### PR Checklist ###

- [ x] Rebased on top of the target branch at time of PR
- [ x] Changes adhere to coding standard